### PR TITLE
Add SMBUS support for Denverton SoC

### DIFF
--- a/chipsec/cfg/dnv.xml
+++ b/chipsec/cfg/dnv.xml
@@ -9,6 +9,7 @@
 -->
   
   <pci>
+    <device name="SMBUS"  bus="0" dev="0x1F" fun="4" vid="0x8086" />
   </pci>
 
 
@@ -19,6 +20,7 @@
   <io>
     <bar name="ABASE"    register="ABASE"    base_field="Base"  size="0x100"  desc="ACPI Base Address"/>
     <bar name="TCOBASE"  register="TCOBASE"  base_field="Base"  size="0x20"   desc="TCO Base Address"/>
+    <bar name="SMBUS_BASE" bus="0" dev="0x1F" fun="4" reg="0x20" mask="0xFFE0" size="0x80" desc="SMBus Base Address"/>
   </io>
 
   <memory>

--- a/chipsec/cfg/dnv.xml
+++ b/chipsec/cfg/dnv.xml
@@ -45,6 +45,15 @@
       <field  name="Base" bit="5" size="11" desc="Base Address"/>
     </register>
 
+    <!-- SMBus Host Controller -->
+    <register name="SMBUS_HCFG" type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x40" size="1" desc="Host Configuration">
+      <field name="HST_EN"     bit="0" size="1"/>
+      <field name="SMB_SMI_EN" bit="1" size="1"/>
+      <field name="I2C_EN"     bit="2" size="2"/>
+      <field name="SSRESET"    bit="3" size="1"/>
+      <field name="SPD_WD"     bit="4" size="1"/>
+    </register>
+
     <!-- SPI Flash Controller MMIO registers -->
     <register name="HSFS" type="mmio" bar="SPIBAR" offset="0x04" size="4" desc="Hardware Sequencing Flash Status Register">
       <field name="SCIP"    bit="5"  size="1" desc="SPI cycle in progress"/>


### PR DESCRIPTION
Tested in UEFI environment, e.g. dump DDR SPD data:
python chipsec_util.py smbus read 0xa0 0x0 0x100